### PR TITLE
Support report with XML namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.8
-before_install: gem install bundler -v 2.2.15
+  - 3.3.4
+before_install: gem install bundler -v 2.5.16

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,42 +8,55 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.3)
-    diff-lcs (1.4.4)
-    method_source (1.0.0)
-    mini_portile2 (2.6.1)
-    nokogiri (1.12.4)
-      mini_portile2 (~> 2.6.1)
+    diff-lcs (1.5.1)
+    method_source (1.1.0)
+    nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
-    pry (0.14.1)
+    nokogiri (1.16.7-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.5.2)
-    rake (10.5.0)
+    racc (1.8.1)
+    rake (13.2.1)
     rb-readline (0.5.5)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
 
 PLATFORMS
-  ruby
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)
   dmarc_parser!
   pry
-  rake (~> 10.0)
+  rake (~> 13.0)
   rb-readline
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.2.15
+   2.5.16

--- a/dmarc_parser.gemspec
+++ b/dmarc_parser.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rb-readline"
   spec.add_development_dependency "pry"

--- a/lib/dmarc_parser/report.rb
+++ b/lib/dmarc_parser/report.rb
@@ -11,6 +11,7 @@ module DmarcParser
     def initialize(xml)
       @xml = xml
       @node = Nokogiri::XML(xml)
+      @node.remove_namespaces!
     end
 
     def version

--- a/lib/dmarc_parser/version.rb
+++ b/lib/dmarc_parser/version.rb
@@ -1,3 +1,3 @@
 module DmarcParser
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/support/complete.xml
+++ b/spec/support/complete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<feedback>
+<feedback xmlns="urn:ietf:params:xml:ns:dmarc-2.0">
   <version>0.1</version>
   <report_metadata>
     <org_name>google.com</org_name>


### PR DESCRIPTION
When report has default namespace (e.g. `xmlns="urn:ietf:params:xml:ns:dmarc-2.0"`), we will fail parsing due to XPath missing namespace in it. Fix uses `remove_namespaces!` to get rid of it if report contains it.

Also updated dependencies. 